### PR TITLE
fix dependency injection attribute in Android/Beacon Service

### DIFF
--- a/Covid19Radar/Covid19Radar.Android/Services/BeaconService.cs
+++ b/Covid19Radar/Covid19Radar.Android/Services/BeaconService.cs
@@ -9,15 +9,19 @@ using Android.OS;
 using Android.Runtime;
 using Android.Views;
 using Android.Widget;
+using Covid19Radar.Droid.Services;
 using Covid19Radar.Model;
 using Covid19Radar.Services;
 using Xamarin.Forms;
 
-[assembly: Dependency(typeof(IBeaconService))]
+[assembly: Dependency(typeof(BeaconService))]
 namespace Covid19Radar.Droid.Services
 {
     public class BeaconService : IBeaconService
     {
+        public BeaconService()
+        {
+        }
         #region IBeaconService implementation
         public Dictionary<string,BeaconDataModel> GetBeaconData()
         {


### PR DESCRIPTION
"implementorType" should use Actually type in the each platform.

FYI: http://coelacanth.jp.net/xamarin_missingmethodexception/

note: We should replace the implementation of iOS Project 